### PR TITLE
Allow selection of external security keys when creating passkey

### DIFF
--- a/packages/jazz-browser/src/auth/PasskeyAuth.ts
+++ b/packages/jazz-browser/src/auth/PasskeyAuth.ts
@@ -130,7 +130,6 @@ export class BrowserPasskeyAuth {
           },
           pubKeyCredParams: [{ alg: -7, type: "public-key" }],
           authenticatorSelection: {
-            authenticatorAttachment: "platform",
             requireResidentKey: true,
             residentKey: "required",
           },


### PR DESCRIPTION
Deleting the line removes the restriction of only being able to select on-device passkey creation. 

This will allow using an external security key, for example a yubikey, when creating an account. 